### PR TITLE
Add `rye format` and `rye lint` to the pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,15 @@ repos:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
+  - repo: local
+    hooks:
+      - id: check-format
+        name: check-format
+        entry: rye fmt --check
+        language: system
+        types: [python]
+      - id: lint
+        name: lint
+        entry: rye lint
+        language: system
+        types: [python]


### PR DESCRIPTION
> Set up a project.
> Set up a descent linting/formatting tools.
> Configure the CI.
> Add modern pre-commit git hooks managers.
> Not use them for running formatters and linters.

This patch adds the hooks for checking formatting and linting of the python code to the pre-commit configuration.